### PR TITLE
Use Vite's envDir option if specified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
                     viteDevServerUrl = `${protocol}://${host}:${address.port}`
                     fs.writeFileSync(hotFile, viteDevServerUrl)
 
-                    const envDir = resolvedConfig.envDir || process.cwd();
+                    const envDir = resolvedConfig.envDir || process.cwd()
                     const appUrl = loadEnv('', envDir, 'APP_URL').APP_URL
 
                     setTimeout(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,10 +124,11 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
                     viteDevServerUrl = `${protocol}://${host}:${address.port}`
                     fs.writeFileSync(hotFile, viteDevServerUrl)
 
-                    const appUrl = loadEnv('', resolvedConfig.envDir || process.cwd(), 'APP_URL').APP_URL
+                    const envDir = resolvedConfig.envDir || process.cwd();
+                    const appUrl = loadEnv('', envDir, 'APP_URL').APP_URL
 
                     setTimeout(() => {
-                        server.config.logger.info(colors.red(`\n  Laravel ${laravelVersion(resolvedConfig.envDir)} `))
+                        server.config.logger.info(colors.red(`\n  Laravel ${laravelVersion(envDir)} `))
                         server.config.logger.info(`\n  > APP_URL: ` + colors.cyan(appUrl))
                     })
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,10 +124,10 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
                     viteDevServerUrl = `${protocol}://${host}:${address.port}`
                     fs.writeFileSync(hotFile, viteDevServerUrl)
 
-                    const appUrl = loadEnv('', process.cwd(), 'APP_URL').APP_URL
+                    const appUrl = loadEnv('', resolvedConfig.envDir || process.cwd(), 'APP_URL').APP_URL
 
                     setTimeout(() => {
-                        server.config.logger.info(colors.red(`\n  Laravel ${laravelVersion()} `))
+                        server.config.logger.info(colors.red(`\n  Laravel ${laravelVersion(resolvedConfig.envDir)} `))
                         server.config.logger.info(`\n  > APP_URL: ` + colors.cyan(appUrl))
                     })
                 }
@@ -194,9 +194,9 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
 /**
  * The version of Laravel being run.
  */
-function laravelVersion(): string {
+function laravelVersion(envDir?: string): string {
     try {
-        const composer = JSON.parse(fs.readFileSync('composer.lock').toString())
+        const composer = JSON.parse(fs.readFileSync(`${envDir}composer.lock`).toString())
 
         return composer.packages?.find((composerPackage: {name: string}) => composerPackage.name === 'laravel/framework')?.version ?? ''
     } catch {


### PR DESCRIPTION
Vite allows you to pass through a custom option for the envDir.
This is useful in cases where you might have multiple frontend packages and so your vite.config.js is not in the root directory.

This update checks for that config option and if so will use it over the current directory when resolving the APP_URL and laravel version.